### PR TITLE
Remove FloatMath for API 23+

### DIFF
--- a/library/src/com/viewpagerindicator/LinePageIndicator.java
+++ b/library/src/com/viewpagerindicator/LinePageIndicator.java
@@ -27,7 +27,6 @@ import android.support.v4.view.MotionEventCompat;
 import android.support.v4.view.ViewConfigurationCompat;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
-import android.util.FloatMath;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -369,7 +368,7 @@ public class LinePageIndicator extends View implements PageIndicator {
                 result = Math.min(result, specSize);
             }
         }
-        return (int)FloatMath.ceil(result);
+        return (int) Math.ceil(result);
     }
 
     /**
@@ -395,7 +394,7 @@ public class LinePageIndicator extends View implements PageIndicator {
                 result = Math.min(result, specSize);
             }
         }
-        return (int)FloatMath.ceil(result);
+        return (int) Math.ceil(result);
     }
 
     @Override


### PR DESCRIPTION
FloatMath was depreciated, and now removed in API 23